### PR TITLE
toggle label  center

### DIFF
--- a/react-auth/src/TaskCard.tsx
+++ b/react-auth/src/TaskCard.tsx
@@ -236,18 +236,17 @@ export const TaskCard: FC<{ token: string }> = (props) => {
         {dev && ai && <br />}
         {dev && ai && <br />}
         <Form onSubmit={(e) => makeTask(e)}>
-          <Form.Switch
-            className="d-flex align-items-center toggle" // Add d-flex and align-items-center classes
-            type="switch"
-            id="custom-switch"
-            label={
-              <span style={{ marginRight: "10px", paddingLeft: "5px" }}>
-                {dev ? "Disable Developer Mode" : "Enable Developer Mode"}
-              </span>
-            }
-            checked={dev}
-            onChange={() => toggleDev()}
-          />
+          <div className="d-flex align-items-end">
+            <Form.Switch
+              type="switch"
+              id="custom-switch"
+              checked={dev}
+              onChange={() => toggleDev()}
+            />
+            <Form.Label className="text-center m-0">
+              {dev ? "Disable Developer Mode" : "Enable Developer Mode"}
+            </Form.Label>
+          </div>
           &nbsp;
           {ai && (
             <Form.Group className="mb-3" controlId="formBasicEmail">
@@ -263,18 +262,17 @@ export const TaskCard: FC<{ token: string }> = (props) => {
           )}
           {!ai && <p>manual task creation coming soon</p>}
           {dev && (
-            <Form.Switch
-              className="d-flex align-items-center toggle" // Add d-flex and align-items-center classes
-              type="switch"
-              id="custom-switch"
-              label={
-                <span style={{ marginRight: "10px", paddingLeft: "5px" }}>
-                  {ai ? "Disable AI Mode" : "Enable AI Mode"}
-                </span>
-              }
-              checked={ai}
-              onChange={() => toggleAi()}
-            />
+            <div className="d-flex align-items-end">
+              <Form.Switch
+                type="switch"
+                id="custom-switch"
+                checked={ai}
+                onChange={() => toggleAi()}
+              />
+              <Form.Label className="text-center m-0">
+                {ai ? "Disable AI Mode" : "Enable AI Mode"}
+              </Form.Label>
+            </div>
           )}
         </Form>
         <Table>


### PR DESCRIPTION
Closes Issue #223

I found that it was react-native form.switch issue. 
Before:
As you can see this, the toggle sticks to the bottom in Form container without changing any style. 
So, I set align setting to the bottom and separated the label and toggle for looks cleaner look.
![Screenshot 2024-04-17 at 23 34 21](https://github.com/raspberri05/taskorial/assets/57412714/b1cf011e-1f74-4aef-a547-bc580683c3b6)


After:
![Screenshot 2024-04-17 at 23 23 01](https://github.com/raspberri05/taskorial/assets/57412714/df5a1938-1131-4256-a75c-f94dcfc8d234)




### What's being changed (it is reccomended to show visual proof of the changes if applicable)



### Check off the following:

- [v] I have followed the contribution guidelines of this repository in making my contributions
